### PR TITLE
Melhora a eficiência da paginação e contagem de estações

### DIFF
--- a/index.html
+++ b/index.html
@@ -724,8 +724,16 @@ audioPlayer.onerror = (e) => {
             }
 
             try {
-                const countResponse = await fetchData('/stations/search', { ...filters, limit: 100000 });
-                totalStations = countResponse.length;
+                // Create countFilters from the global filters object
+                const countFilters = {
+                    name: filters.name,
+                    country: filters.country,
+                    language: filters.language,
+                    tagList: filters.tagList,
+                    hidebroken: filters.hidebroken !== undefined ? filters.hidebroken : true
+                };
+                const countResponse = await fetchData('/stations/search/count', countFilters);
+                totalStations = parseInt(countResponse.value, 10);
                 const stationsData = await fetchData('/stations/search', filters);
                 stations = stationsData;
                 currentStationIndex = 0;


### PR DESCRIPTION
Este commit corrige uma ineficiência na forma como o número total de estações era calculado para a paginação.

Anteriormente, a aplicação buscava até 100.000 registros de estações apenas para obter a contagem total, o que era desnecessário e consumia muitos recursos.

A lógica foi alterada para:
1. Utilizar o endpoint `/stations/search/count` da API Radio Browser para obter a contagem total de estações.
2. Passar os mesmos filtros da sua pesquisa principal (nome, país, idioma, tag) para o endpoint de contagem, garantindo que a contagem reflita os critérios de busca atuais.
3. Assegurar que a contagem total (`totalStations`) seja atualizada antes de buscar os dados das estações para a página exibida.

Isso resulta em uma busca de contagem muito mais rápida e eficiente, melhorando o desempenho geral da funcionalidade de pesquisa e paginação.